### PR TITLE
Set priority for newsListFetchItems

### DIFF
--- a/src/EventListener/NewsListener.php
+++ b/src/EventListener/NewsListener.php
@@ -100,7 +100,7 @@ class NewsListener {
      *
      * @return Model\Collection|NewsModel|false
      *
-     * @Hook("newsListFetchItems")
+     * @Hook("newsListFetchItems", priority=100)
      */
     public function newsListFetchItems( $newsArchives, $blnFeatured, $limit, $offset, ModuleNewsList $module ) {
 


### PR DESCRIPTION
Set priority for newsListFetchItems for better collaboration with news categories

see also https://github.com/codefog/contao-news_categories/pull/258